### PR TITLE
Configure for remote build: update .funcignore and azure.yaml

### DIFF
--- a/app/.funcignore
+++ b/app/.funcignore
@@ -1,5 +1,4 @@
 *.js.map
-*.ts
 .git*
 .vscode
 __azurite_db*__.json
@@ -7,4 +6,4 @@ __blobstorage__
 __queuestorage__
 local.settings.json
 test
-tsconfig.json
+node_modules

--- a/azure.yaml
+++ b/azure.yaml
@@ -8,6 +8,7 @@ services:
     project: ./app/
     language: js
     host: function
+    remoteBuild: true
 hooks:
   postprovision:
     windows:


### PR DESCRIPTION
This PR configures the project for remote build when deploying with `azd`.

## Changes

### `app/.funcignore`
- Removed `*.ts` and `tsconfig.json` entries (not needed for JS projects)
- Added `node_modules` to ensure dependencies are installed during remote build instead of being uploaded

### `azure.yaml`
- Added `remoteBuild: true` to the service configuration

## Why

When deploying with `azd`, remote build is used. The `.funcignore` should exclude `node_modules` so that dependencies are installed on the server during deployment rather than being uploaded from the local machine. This avoids issues with platform-specific native binaries and reduces deployment package size.

## About `remoteBuild: true` in `azure.yaml`

The `remoteBuild: true` flag in `azure.yaml` is being added ahead of support in `azd`. See https://github.com/Azure/azure-dev/pull/6748.

Adding this flag now has no effect on current versions of `azd`, but will be used by new versions that support it. The goal is to explicitly pin the remote build behavior for this project so that it is not affected by potential future changes to the default build behavior in `azd`.